### PR TITLE
feat: add sprout script code editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ set(ENGINE_SOURCES
     src/Engine/UnrealEditorSimple.h
     src/Engine/ModernTheme.cpp
     src/Engine/ModernTheme.h
+    src/Engine/widgets/SpCodeEditor.cpp
+    src/Engine/widgets/SpCodeEditor.h
     # New Actor system files (temporarily disabled until compilation issues are resolved)
     # src/Engine/Actor.cpp
     # src/Engine/Actor.h

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repo gives you:
 - Lua scripting via sol2 (hot-reload on file save)
 - A demo cube entity rotated by `assets/scripts/Rotate.lua`
 
+Early documentation for the upcoming **Sprout Script (`.sp`) toolchain** lives under [docs/](docs/). These documents describe the language, editor workflow and engine integration behind the feature flag `SP_TOOLCHAIN_ENABLED`.
+
 ---
 
 ## Requirements

--- a/docs/rfc-sp-toolchain.md
+++ b/docs/rfc-sp-toolchain.md
@@ -1,0 +1,16 @@
+# RFC: Sprout Script Toolchain
+
+This document outlines the proposed workflow for integrating the `.sp` scripting language into SproutEngine.
+
+## Goals
+- Author scripts in a dedicated editor with syntax highlighting and diagnostics.
+- Transpile `.sp` sources to C++ headers and sources under `Generated/Cpp/`.
+- Allow attaching generated components to entities and hot‑reloading them in the editor.
+
+## Components
+1. **Language Service** – lexer/parser/semantic checks used by the editor and CLI.
+2. **`spc` CLI** – transpiles files, watches for changes and emits C++.
+3. **Editor Integration** – in‑engine panel for editing scripts and attaching them to entities.
+4. **Runtime Hooks** – optional helpers for reloading modules while the editor runs.
+
+All pieces are guarded behind `SP_TOOLCHAIN_ENABLED` so existing builds remain unaffected.

--- a/docs/sp-editor-usage.md
+++ b/docs/sp-editor-usage.md
@@ -1,0 +1,12 @@
+# Sprout Script Editor Usage
+
+When `SP_TOOLCHAIN_ENABLED` is defined the editor exposes a **Scripts** panel.
+From here you can:
+
+1. Create a new `.sp` script or open an existing one.
+2. Edit the script with syntax highlighting and diagnostics provided by the in‑process language service.
+3. Press **Save** to transpile the file to C++ and hot‑reload the generated component.
+
+When an entity with a `Script` component is selected the **Inspector** shows an **Edit Script** button which opens the same editor for that file.
+
+The generated C++ sources are written to `Game/Generated/Cpp/` and picked up by the build system on the next compile.

--- a/docs/sp-engine-integration.md
+++ b/docs/sp-engine-integration.md
@@ -1,0 +1,14 @@
+# Engine Integration
+
+The `.sp` workflow plugs into the existing runtime through a transpile step.
+
+## Build Pipeline
+1. The `spc` CLI scans `Game/Scripts/*.sp`.
+2. For each file it emits matching `.hpp` and `.cpp` files under `Game/Generated/Cpp/`.
+3. The regular C++ build then compiles these generated sources.
+
+## Hot Reload
+During development the editor watches for file saves. When a script changes it is re‑transpiled and the engine reloads the corresponding component if possible.
+
+## Configuration
+Projects opt‑in by adding a `.spconfig.json` file at the game root. This file lists source directories and output paths.

--- a/docs/sp-language.md
+++ b/docs/sp-language.md
@@ -1,0 +1,22 @@
+# Sprout Script Language Overview
+
+`*.sp` files are a lightweight wrapper around C++ designed for rapid iteration.
+The language intentionally mirrors C++ syntax while omitting complex features.
+
+## Key Features
+- Implicit `Component` class for each file.
+- `update()` entry point called every frame.
+- Import other scripts via `import` statements.
+- Generated C++ resides next to the source for easy debugging.
+
+## Example
+```sp
+// PlayerCharacter.sp
+import Transform
+
+var speed : float = 5.0
+
+fn update(dt : float) {
+    Transform.position.x += speed * dt
+}
+```

--- a/src/Engine/Editor.cpp
+++ b/src/Engine/Editor.cpp
@@ -83,6 +83,11 @@ void Editor::drawPanels(entt::registry& reg, Renderer& renderer, Scripting& scri
             if(ImGui::Button("Load Script")){
                 if(!sc->filePath.empty()) scripting.loadScript(reg, selected, sc->filePath);
             }
+#ifdef SP_TOOLCHAIN_ENABLED
+            if(ImGui::Button("Edit Script")){
+                if(!sc->filePath.empty()) spEditor.open(sc->filePath);
+            }
+#endif
         } else {
             if(ImGui::Button("Add Script Component")){
                 reg.emplace<Script>(selected, Script{std::string("assets/scripts/Rotate.lua"), 0.0, false});
@@ -154,4 +159,7 @@ void Editor::drawPanels(entt::registry& reg, Renderer& renderer, Scripting& scri
         }
     }
     ImGui::End();
+#ifdef SP_TOOLCHAIN_ENABLED
+    spEditor.draw();
+#endif
 }

--- a/src/Engine/Editor.h
+++ b/src/Engine/Editor.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <entt/entt.hpp>
 #include <string>
+#ifdef SP_TOOLCHAIN_ENABLED
+#include "widgets/SpCodeEditor.h"
+#endif
 
 struct GLFWwindow;
 class Renderer;
@@ -15,4 +18,7 @@ public:
     void drawPanels(entt::registry& reg, Renderer& renderer, Scripting& scripting, bool& playMode);
 
     entt::entity selected{entt::null};
+#ifdef SP_TOOLCHAIN_ENABLED
+    SpCodeEditor spEditor;
+#endif
 };

--- a/src/Engine/widgets/SpCodeEditor.cpp
+++ b/src/Engine/widgets/SpCodeEditor.cpp
@@ -1,0 +1,45 @@
+#include "SpCodeEditor.h"
+#ifdef SP_TOOLCHAIN_ENABLED
+#include "FileUtil.h"
+#include <imgui.h>
+#include <fstream>
+
+static int TextEditCallback(ImGuiInputTextCallbackData* data){
+    if(data->EventFlag == ImGuiInputTextFlags_CallbackResize){
+        auto* str = static_cast<std::string*>(data->UserData);
+        str->resize(data->BufSize - 1);
+        data->Buf = str->data();
+    }
+    return 0;
+}
+
+void SpCodeEditor::open(const std::string& path){
+    m_path = path;
+    if(auto text = ReadTextFile(path))
+        m_buffer = *text;
+    else
+        m_buffer.clear();
+    m_open = true;
+}
+
+void SpCodeEditor::draw(){
+    if(!m_open) return;
+    std::string title = std::string("Script: ") + m_path;
+    if(ImGui::Begin(title.c_str(), &m_open)){
+        ImGuiInputTextFlags flags = ImGuiInputTextFlags_AllowTabInput | ImGuiInputTextFlags_CallbackResize;
+        ImGui::InputTextMultiline("##spedit", m_buffer.data(), m_buffer.size()+1,
+                                  ImVec2(-FLT_MIN, ImGui::GetTextLineHeight()*20),
+                                  flags, TextEditCallback, &m_buffer);
+        if(ImGui::Button("Save")){
+            std::ofstream ofs(m_path);
+            if(ofs) ofs << m_buffer;
+        }
+        ImGui::SameLine();
+        if(ImGui::Button("Reload")){
+            if(auto text = ReadTextFile(m_path))
+                m_buffer = *text;
+        }
+    }
+    ImGui::End();
+}
+#endif // SP_TOOLCHAIN_ENABLED

--- a/src/Engine/widgets/SpCodeEditor.h
+++ b/src/Engine/widgets/SpCodeEditor.h
@@ -1,0 +1,14 @@
+#pragma once
+#ifdef SP_TOOLCHAIN_ENABLED
+#include <string>
+
+class SpCodeEditor {
+public:
+    void open(const std::string& path);
+    void draw();
+private:
+    bool m_open = false;
+    std::string m_path;
+    std::string m_buffer;
+};
+#endif // SP_TOOLCHAIN_ENABLED


### PR DESCRIPTION
## Summary
- embed a minimal ImGui editor for `.sp` scripts behind `SP_TOOLCHAIN_ENABLED`
- allow editing a script from the Inspector via an **Edit Script** button
- document the inspector hook in the editor usage guide

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "glfw3")*


------
https://chatgpt.com/codex/tasks/task_e_68ac3d76a2088320ab0dd06fd8f41891