### PR TITLE
Enable ImGui docking for editor panels

### DIFF
--- a/src/Engine/Editor.cpp
+++ b/src/Engine/Editor.cpp
@@ -13,6 +13,10 @@
 bool Editor::init(GLFWwindow* window){
     (void)window;
     IMGUI_CHECKVERSION();
+    // Enable docking so panels can be attached to screen corners
+    ImGuiIO& io = ImGui::GetIO();
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+
     // Theme
     Theme::SetupImGuiTheme();
     imnodes::Initialize();
@@ -25,7 +29,8 @@ void Editor::shutdown(GLFWwindow* window){
 }
 
 void Editor::drawDockspace(){
-    ImGui::Begin("Main"); ImGui::TextUnformatted("SproutEngine"); ImGui::End();
+    // Create a full-screen dock space allowing windows to dock to all sides
+    ImGui::DockSpaceOverViewport(ImGui::GetMainViewport());
 }
 
 static void Vec3Control(const char* label, glm::vec3& v){


### PR DESCRIPTION
## Summary
- enable ImGui docking in Editor initialization
- add full-screen dock space so panels can snap to window edges

## Testing
- `cmake -S . -B build` *(fails: could not find package configuration file provided by "glad" )*

------
https://chatgpt.com/codex/tasks/task_e_68ac420ba88c83208d896089ceca7d50